### PR TITLE
Update testlists

### DIFF
--- a/driver/cime_config/testdefs/testlist_drv.xml
+++ b/driver/cime_config/testdefs/testlist_drv.xml
@@ -7,14 +7,14 @@
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="edison" compiler="cray" category="prebeta">
+      <machine name="cori-haswell" compiler="cray" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
   </test>
-  <test name="ERI" grid="ne30_g16" compset="X">
+  <test name="ERI" grid="ne30_g17" compset="X">
     <machines>
       <machine name="cheyenne" compiler="pgi" category="prebeta">
         <options>
@@ -34,17 +34,17 @@
   </test>
   <test name="ERI_D" grid="T31_g37_rx1" compset="A">
     <machines>
-      <machine name="hobart" compiler="intel" category="prebeta">
+      <machine name="izumi" compiler="intel" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="hobart" compiler="pgi" category="prebeta">
+      <machine name="izumi" compiler="pgi" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="edison" compiler="intel" category="prebeta">
+      <machine name="cori-haswell" compiler="intel" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
@@ -66,7 +66,7 @@
       </machine>
     </machines>
   </test>
-  <test name="SMS" grid="f19_g16" compset="X">
+  <test name="SMS" grid="f19_g17" compset="X">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_cime_baselines">
 	<options>
@@ -97,17 +97,12 @@
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="hobart" compiler="nag" category="prealpha">
+      <machine name="izumi" compiler="nag" category="prealpha">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="eos" compiler="cray" category="prealpha">
-        <options>
-          <option name="wallclock">00:30:00</option>
-        </options>
-      </machine>
-      <machine name="edison" compiler="intel" category="prealpha">
+      <machine name="cori-haswell" compiler="intel" category="prealpha">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
@@ -124,7 +119,7 @@
       </machine>
     </machines>
   </test>
-  <test name="ERS_IOP_Ld3" grid="f19_g16_rx1" compset="A">
+  <test name="ERS_IOP_Ld3" grid="f19_g17_rx1" compset="A">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="prebeta">
         <options>
@@ -143,7 +138,7 @@
       </machine>
     </machines>
   </test>
-  <test name="ERS_IOP_Ld3" grid="ne30_g16_rx1" compset="A">
+  <test name="ERS_IOP_Ld3" grid="ne30_g17_rx1" compset="A">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="prebeta">
         <options>
@@ -169,22 +164,12 @@
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="edison" compiler="intel" category="prealpha">
+      <machine name="cori-haswell" compiler="intel" category="prealpha">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="edison" compiler="intel" category="prebeta">
-        <options>
-          <option name="wallclock">00:30:00</option>
-        </options>
-      </machine>
-      <machine name="eos" compiler="intel" category="prealpha">
-        <options>
-          <option name="wallclock">00:30:00</option>
-        </options>
-      </machine>
-      <machine name="eos" compiler="cray" category="prebeta">
+      <machine name="cori-haswell" compiler="intel" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
@@ -194,7 +179,7 @@
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="edison" compiler="cray" category="prebeta">
+      <machine name="cori-haswell" compiler="cray" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
@@ -203,17 +188,17 @@
   </test>
   <test name="ERS_Ld3" grid="f45_g37_rx1" compset="A">
     <machines>
-      <machine name="edison" compiler="intel" category="prebeta">
+      <machine name="cori-haswell" compiler="intel" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="hobart" compiler="intel" category="prealpha">
+      <machine name="izumi" compiler="intel" category="prealpha">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="hobart" compiler="pgi" category="prealpha">
+      <machine name="izumi" compiler="pgi" category="prealpha">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
@@ -233,14 +218,14 @@
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="hobart" compiler="lahey" category="prebeta">
+      <machine name="izumi" compiler="lahey" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
   </test>
-  <test name="ERS_Ld3" grid="f19_g16_rx1" compset="A">
+  <test name="ERS_Ld3" grid="f19_g17_rx1" compset="A">
     <machines>
       <machine name="bluewaters" compiler="pgi" category="prealpha">
         <options>
@@ -252,35 +237,30 @@
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="eos" compiler="intel" category="prebeta">
+    </machines>
+  </test>
+  <test name="ERS_Ld3" grid="ne30_g17_rx1" compset="A">
+    <machines>
+      <machine name="cori-haswell" compiler="intel" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
   </test>
-  <test name="ERS_Ld3" grid="ne30_g16_rx1" compset="A">
+  <test name="ERS_Ld3" grid="f19_g17" compset="X">
     <machines>
-      <machine name="edison" compiler="intel" category="prebeta">
+      <machine name="izumi" compiler="intel" category="prealpha">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-    </machines>
-  </test>
-  <test name="ERS_Ld3" grid="f19_g16" compset="X">
-    <machines>
-      <machine name="hobart" compiler="intel" category="prealpha">
+      <machine name="izumi" compiler="pgi" category="prealpha">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="hobart" compiler="pgi" category="prealpha">
-        <options>
-          <option name="wallclock">00:30:00</option>
-        </options>
-      </machine>
-      <machine name="edison" compiler="intel" category="prealpha">
+      <machine name="cori-haswell" compiler="intel" category="prealpha">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
@@ -299,14 +279,14 @@
   </test>
   <test name="ERS_Ld3" grid="f45_g37" compset="X">
     <machines>
-      <machine name="hobart" compiler="lahey" category="prebeta">
+      <machine name="izumi" compiler="lahey" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
   </test>
-  <test name="ERS_Lm3" grid="T62_g16" compset="AIAF">
+  <test name="ERS_Lm3" grid="T62_g17" compset="AIAF">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha">
         <options>
@@ -317,17 +297,17 @@
   </test>
   <test name="ERS_N2_Ld3" grid="T31_g37_rx1" compset="A">
     <machines>
-      <machine name="hobart" compiler="intel" category="prebeta">
+      <machine name="izumi" compiler="intel" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="hobart" compiler="pgi" category="prebeta">
+      <machine name="izumi" compiler="pgi" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="edison" compiler="intel" category="prebeta">
+      <machine name="cori-haswell" compiler="intel" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
@@ -349,38 +329,28 @@
       </machine>
     </machines>
   </test>
-  <test name="ERS_N2_Ld3" grid="f19_g16_rx1" compset="A">
+  <test name="ERS_N2_Ld3" grid="f19_g17_rx1" compset="A">
     <machines>
       <machine name="bluewaters" compiler="pgi" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="edison" compiler="intel" category="prebeta">
-        <options>
-          <option name="wallclock">00:30:00</option>
-        </options>
-      </machine>
-      <machine name="eos" compiler="intel" category="prebeta">
+      <machine name="cori-haswell" compiler="intel" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
   </test>
-  <test name="NCK_Ld3" grid="f19_g16_rx1" compset="A">
+  <test name="NCK_Ld3" grid="f19_g17_rx1" compset="A">
     <machines>
-      <machine name="hobart" compiler="intel" category="prebeta">
+      <machine name="izumi" compiler="intel" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="hobart" compiler="pgi" category="prebeta">
-        <options>
-          <option name="wallclock">00:30:00</option>
-        </options>
-      </machine>
-      <machine name="eos" compiler="intel" category="prebeta">
+      <machine name="izumi" compiler="pgi" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
@@ -409,12 +379,7 @@
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="edison" compiler="intel" category="prebeta">
-        <options>
-          <option name="wallclock">00:30:00</option>
-        </options>
-      </machine>
-      <machine name="eos" compiler="intel" category="prebeta">
+      <machine name="cori-haswell" compiler="intel" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
@@ -459,7 +424,7 @@
       </machine>
     </machines>
   </test>
-  <test name="PEM" grid="f19_g16_rx1" compset="A">
+  <test name="PEM" grid="f19_g17_rx1" compset="A">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha">
         <options>
@@ -470,7 +435,26 @@
   </test>
   <test name="PET_Ld3" grid="f45_g37_rx1" compset="A">
     <machines>
-      <machine name="eos" compiler="cray" category="prebeta">
+      <machine name="cheyenne" compiler="gnu" category="prebeta">
+        <options>
+          <option name="wallclock">00:30:00</option>
+        </options>
+      </machine>
+      <machine name="cheyenne" compiler="intel" category="prebeta">
+        <options>
+          <option name="wallclock">00:30:00</option>
+        </options>
+      </machine>
+      <machine name="cheyenne" compiler="pgi" category="prebeta">
+        <options>
+          <option name="wallclock">00:30:00</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+  <test name="PET_Ld3" grid="f19_g17" compset="X">
+    <machines>
+      <machine name="izumi" compiler="pgi" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
@@ -492,14 +476,9 @@
       </machine>
     </machines>
   </test>
-  <test name="PET_Ld3" grid="f19_g16" compset="X">
+  <test name="SEQ_IOP_Ld3" grid="f19_g17" compset="X">
     <machines>
-      <machine name="hobart" compiler="pgi" category="prebeta">
-        <options>
-          <option name="wallclock">00:30:00</option>
-        </options>
-      </machine>
-      <machine name="eos" compiler="cray" category="prebeta">
+      <machine name="izumi" compiler="pgi" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
@@ -521,47 +500,9 @@
       </machine>
     </machines>
   </test>
-  <test name="SEQ_IOP_Ld3" grid="f19_g16" compset="X">
+  <test name="SEQ_Ld3" grid="f09_g17" compset="X">
     <machines>
-      <machine name="hobart" compiler="pgi" category="prebeta">
-        <options>
-          <option name="wallclock">00:30:00</option>
-        </options>
-      </machine>
-      <machine name="eos" compiler="cray" category="prebeta">
-        <options>
-          <option name="wallclock">00:30:00</option>
-        </options>
-      </machine>
-      <machine name="cheyenne" compiler="gnu" category="prebeta">
-        <options>
-          <option name="wallclock">00:30:00</option>
-        </options>
-      </machine>
-      <machine name="cheyenne" compiler="intel" category="prebeta">
-        <options>
-          <option name="wallclock">00:30:00</option>
-        </options>
-      </machine>
-      <machine name="cheyenne" compiler="pgi" category="prebeta">
-        <options>
-          <option name="wallclock">00:30:00</option>
-        </options>
-      </machine>
-    </machines>
-  </test>
-  <test name="SEQ_Ld3" grid="f09_g16" compset="X">
-    <machines>
-      <machine name="edison" compiler="intel" category="prebeta">
-        <options>
-          <option name="wallclock">00:30:00</option>
-        </options>
-      </machine>
-    </machines>
-  </test>
-  <test name="SEQ_Ld3" grid="f19_g16" compset="X">
-    <machines>
-      <machine name="eos" compiler="intel" category="prebeta">
+      <machine name="cori-haswell" compiler="intel" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
@@ -570,26 +511,21 @@
   </test>
   <test name="SMS_D_Ld3" grid="f45_g37_rx1" compset="A">
     <machines>
-      <machine name="hobart" compiler="nag" category="prealpha">
+      <machine name="izumi" compiler="nag" category="prealpha">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
-      <machine name="hobart" compiler="nag" category="prebeta">
+      <machine name="izumi" compiler="nag" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
       </machine>
     </machines>
   </test>
-  <test name="SMS_Ld3" grid="f19_g16_rx1" compset="A">
+  <test name="SMS_Ld3" grid="f19_g17_rx1" compset="A">
     <machines>
-      <machine name="hobart" compiler="pgi" category="prebeta">
-        <options>
-          <option name="wallclock">00:30:00</option>
-        </options>
-      </machine>
-      <machine name="eos" compiler="cray" category="prebeta">
+      <machine name="izumi" compiler="pgi" category="prebeta">
         <options>
           <option name="wallclock">00:30:00</option>
         </options>
@@ -618,7 +554,7 @@
   </test>
   <test name="DAE" grid="ww3a" compset="ADWAV">
     <machines>
-      <machine name="hobart" compiler="nag" category="prealpha"/>
+      <machine name="izumi" compiler="nag" category="prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 00:20:00 </option>
@@ -626,7 +562,7 @@
   </test>
   <test name="PRE" grid="f09_f09" compset="ADESP">
     <machines>
-      <machine name="hobart" compiler="nag" category="pauseresume"/>
+      <machine name="izumi" compiler="nag" category="pauseresume"/>
     </machines>
     <options>
       <option name="wallclock"> 00:20:00 </option>
@@ -634,9 +570,9 @@
   </test>
   <test name="PRE" grid="f19_f19" compset="ADESP_TEST">
     <machines>
-      <machine name="hobart" compiler="gnu" category="prealpha"/>
-      <machine name="hobart" compiler="nag" category="prealpha"/>
-      <machine name="hobart" compiler="nag" category="pauseresume"/>
+      <machine name="izumi" compiler="gnu" category="prealpha"/>
+      <machine name="izumi" compiler="nag" category="prealpha"/>
+      <machine name="izumi" compiler="nag" category="pauseresume"/>
     </machines>
     <options>
       <option name="wallclock"> 00:20:00 </option>
@@ -644,7 +580,7 @@
   </test>
   <test name="PRE_N2" grid="f19_f19" compset="ADESP_TEST">
     <machines>
-      <machine name="hobart" compiler="nag" category="pauseresume"/>
+      <machine name="izumi" compiler="nag" category="pauseresume"/>
     </machines>
     <options>
       <option name="wallclock"> 00:20:00 </option>
@@ -652,7 +588,7 @@
   </test>
   <test name="PRE_N2" grid="f19_f19" compset="ADESP_TEST" testmods="drv/multi_driver">
     <machines>
-      <machine name="hobart" compiler="nag" category="pauseresume"/>
+      <machine name="izumi" compiler="nag" category="pauseresume"/>
     </machines>
     <options>
       <option name="wallclock"> 00:20:00 </option>


### PR DESCRIPTION
- Replace _g16 with _g17.
- Move hobart tests to izumi.
- Move edison tests to cori-haswell.
- Remove eos tests.
