### PR TITLE
add DIN_STAGING_ROOT variable

### DIFF
--- a/driver/cime_config/config_component.xml
+++ b/driver/cime_config/config_component.xml
@@ -2159,6 +2159,20 @@
     $CIMEROOT/machines/config_machines.xml</desc>
   </entry>
 
+  <entry id="DIN_STAGING_ROOT">
+    <type>char</type>
+    <default_value>UNSET</default_value>
+    <group>run_din</group>
+    <file>env_run.xml</file>
+    <desc>
+      On some systems the filesystem of DIN_LOC_ROOT is not available on compute nodes and
+      data must be staged to a temporary location.  If this variable is defined it will
+      be used as the root directory of an inputdata staging area.
+      Default values for the target machine are in the
+      $CIMEROOT/machines/config_machines.xml
+    </desc>
+  </entry>
+
   <entry id="DOUT_S_ROOT">
     <type>char</type>
     <default_value>UNSET</default_value>


### PR DESCRIPTION
Adds a variable DIN_STAGING_ROOT for systems where inputdata must be staged to scratch prior to running.  See https://github.com/ESMCI/cime/pull/4118 for details. 