### PR TITLE
support for job_priority on derecho

### DIFF
--- a/driver/cime_config/config_component.xml
+++ b/driver/cime_config/config_component.xml
@@ -519,6 +519,15 @@
    <desc>List of job ids for most recent case.submit</desc>
  </entry>
 
+ <entry id="JOB_PRIORITY">
+   <type>char</type>
+   <default_value>regular</default_value>
+   <valid_values>regular,premium,economy</valid_values>
+   <group>run_begin_stop_restart</group>
+   <file>env_run.xml</file>
+   <desc>job priority for systems supporting this option</desc>
+ </entry>
+
   <!-- ===================================================================== -->
   <!-- definitions archive -->
   <!-- ===================================================================== -->


### PR DESCRIPTION
Adds support for Job priority on derecho.
This requires a cooresponding change in ccs_config