### PR TITLE
replace smp_present with build_threaded

### DIFF
--- a/driver/cime_config/config_component.xml
+++ b/driver/cime_config/config_component.xml
@@ -754,7 +754,7 @@
     different MPI ranks to different GPUs within the same compute node</desc>
   </entry>
 
-  <entry id="SMP_PRESENT">
+  <entry id="BUILD_THREADED">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>


### PR DESCRIPTION
Replace SMP_PRESENT with BUILD_THREADED for a consistent and single variable. 